### PR TITLE
add more padding to thankyou-num class & margin to thankyou-container

### DIFF
--- a/style.css
+++ b/style.css
@@ -131,6 +131,7 @@ input[type="radio"]:hover+label {
   justify-content: center;
   text-align: center;
   display: none;
+  margin-bottom: 10px;
 }
 
 .thankyou-img {
@@ -140,8 +141,8 @@ input[type="radio"]:hover+label {
 .thankyou-num--chosen {
   color: var(--Orange);
   background-color: hsla(216, 12%, 54%, 0.205);
-  font-size: 0.9rem;
-  padding: 0.25rem 0.7rem;
+  font-size: 1rem;
+  padding: 0.7rem 0.7rem;
   border-radius: 30px;
   margin-bottom: 1.8rem;
 }


### PR DESCRIPTION
## Suggested Additions

Hi! 

I noticed that the thank you card seemed to be a little cramped so I added a bit more size and padding to the thankyou-num class and to be consistent with your design additional margin to the bottom of the thank-you-container.  See image below for screen shot of issues identified. 

I'd recommend that the font size of the score chosen take up a little bit more room to highlight its importance on the card component. Adding a bit more size and padding draws more of my attention as a user!

Additionally, I'm curious to hear why your choice of your first line in your JS file: 
``` 
document.addEventListener('DOMContentLoaded', ...
``` 

best, 

Ozzy 

<img width="494" alt="image" src="https://github.com/beveroni/Interactive_rating_component/assets/126006914/0ee241dd-bc51-473b-be66-9ed1afc82f0d">
 